### PR TITLE
Here's something may help.

### DIFF
--- a/graftr
+++ b/graftr
@@ -72,6 +72,16 @@ class _Node:
   def is_directory(self):
     return False
 
+  def clone(self, clone_parent, name=None):
+    parent = self.parent
+    self.parent = None
+    clone = deepcopy(self)
+    clone.parent = clone_parent
+    self.parent = parent
+    if name is not None:
+      clone.name = name
+    return clone
+
 
 class _DirNode(_Node):
   def __init__(self, parent, name):
@@ -246,6 +256,14 @@ class CheckpointShell(Cmd):
     if torch.cuda.is_available():
       return torch.load(checkpoint_path)
     else:
+      print(f'WARNING: Your environment is cpu-only. '
+            f'Do you want to load parameters in \'device:cpu\' (y/N)? ', end='', flush=True)
+      line = sys.stdin.readline().strip().lower()
+      if line != 'y' and line != 'yes':
+        # raise RuntimeError and Trackback to show error and terminate command-line.
+        return torch.load(checkpoint_path)
+      print("")
+      self._dirty = True
       return torch.load(checkpoint_path,
                         map_location=torch.device('cpu'))
 
@@ -491,14 +509,12 @@ class CheckpointShell(Cmd):
       if not dest_node.is_directory:
         print(f'cp: cannot overwrite \'{m.group(2)}\' with \'{m.group(1)}\'.')
         return
-      clone_node = deepcopy(src_node)
+      clone_node = src_node.clone(clone_parent=dest_node)
       dest_node.add_child(clone_node)
-      clone_node.parent = dest_node
     else:
       dest_dir = _dirname(dest)
       dest_name = _basename(dest)
-      clone_node = deepcopy(src_node)
-      clone_node.name = dest_name
+      clone_node = src_node.clone(clone_parent=None, name=dest_name)
       dest_node = self._tree.insert(dest_dir, clone_node)
       clone_node.parent = dest_node
     self._dirty = True

--- a/graftr
+++ b/graftr
@@ -234,12 +234,19 @@ class CheckpointShell(Cmd):
   def __init__(self, checkpoint_path):
     super().__init__()
     self._path = checkpoint_path
-    self._state = torch.load(checkpoint_path)
+    self._state = self.load_checkpoint_path(checkpoint_path)
     self._tree = Tree(self._state)
     self._cwd = self._tree.root
     self._prevwd = '/'
     self._dirty = False
     print(f'Checkpoint loaded from {checkpoint_path}.')
+
+  def load_checkpoint_path(self, checkpoint_path):
+    if torch.cuda.is_available():
+      return torch.load(checkpoint_path)
+    else:
+      return torch.load(checkpoint_path,
+                        map_location=torch.device('cpu'))
 
   def help_shape(self):
     print('shape - print the tensor shape.')
@@ -409,7 +416,7 @@ class CheckpointShell(Cmd):
       return
     if src_node.full_name == dest:
       return
-    if dest.startswith(src_node.full_name):
+    if (dest + '/').startswith(src_node.full_name + '/'):
       print(f'mv: cannot move \'{m.group(1)}\' to a subdirectory of itself, \'{m.group(2)}\'.')
       return
     if dest_node is not None:

--- a/graftr
+++ b/graftr
@@ -21,6 +21,7 @@ import re
 import sys
 
 from cmd import Cmd
+from copy import deepcopy
 from pprint import pprint
 
 
@@ -455,6 +456,51 @@ class CheckpointShell(Cmd):
       print(f'rm: cannot remove root directory.')
       return
     self._rm_node(node)
+    self._dirty = True
+
+  def help_cp(self):
+    print('cp - copy value or directory.')
+    print('Syntax: cp SRC DEST')
+
+  def complete_cp(self, text, line, begidx, endidx):
+    m = re.match(r'mv(\s+[^\s]*)(\s+[^\s]*)?\s*$', line)
+    if not m:
+      return []
+    start = m.start(2) if m.group(2) else m.start(1)
+    end = m.end(2) if m.group(2) else m.end(1)
+    return self._complete_path(line[start:end].strip())
+
+  def do_cp(self, arg):
+    m = re.match(r'([^\s]+)\s+([^\s]+)\s*$', arg)
+    if not m:
+      print(f'cp: invalid usage.')
+      return
+
+    src_node = self._tree.resolve(m.group(1), self._cwd)
+    dest = self._tree.resolve_path(m.group(2), self._cwd)
+    dest_node = self._tree.resolve(dest, self._cwd)
+    if src_node is None:
+      print(f'cp: \'{m.group(1)}\' not found.')
+      return
+    if src_node.full_name == dest:
+      return
+    if (dest + '/').startswith(src_node.full_name + '/'):
+      print(f'cp: cannot copy \'{m.group(1)}\' to a subdirectory of itself, \'{m.group(2)}\'.')
+      return
+    if dest_node is not None:
+      if not dest_node.is_directory:
+        print(f'cp: cannot overwrite \'{m.group(2)}\' with \'{m.group(1)}\'.')
+        return
+      clone_node = deepcopy(src_node)
+      dest_node.add_child(clone_node)
+      clone_node.parent = dest_node
+    else:
+      dest_dir = _dirname(dest)
+      dest_name = _basename(dest)
+      clone_node = deepcopy(src_node)
+      clone_node.name = dest_name
+      dest_node = self._tree.insert(dest_dir, clone_node)
+      clone_node.parent = dest_node
     self._dirty = True
 
   def help_save(self):


### PR DESCRIPTION
I like this repository very much, Thanks for your idea sharing!       
As shown below, there are some updates I made, hope it brings you something.

## Correct Subdirectory Judge

**Before** 
```bash
> ls
bi_lstm/
candidate_module_list/
final_linear_list/
operator_embedding/
position_encoding/
relation_module_list/
word_embedding/
> mv word_embedding word_embeddings
mv: cannot move 'word_embedding' to a subdirectory of itself, 'word_embeddings'.
> exit()
```

** After **
``` bash
> mv word_embedding word_embeddings
> ls
bi_lstm/
candidate_module_list/
final_linear_list/
operator_embedding/
position_encoding/
relation_module_list/
word_embeddings/
> exit()
WARNING: there are pending changes that have not been saved to disk. Discard (y/N)?
```

## Allow loading on a CPU-only machine
**Before**
``` bash
$ ./graftr ./model_save_2018-01-18-175659.pt
Traceback (most recent call last):
  File "./graftr", line 573, in <module>
    CheckpointShell(sys.argv[1]).cmdloop()
  File "./graftr", line 238, in __init__
    self._state = torch.load(checkpoint_path)
  File "D:\Anaconda\lib\site-packages\torch\serialization.py", line 386, in load
    return _load(f, map_location, pickle_module, **pickle_load_args)
  File "D:\Anaconda\lib\site-packages\torch\serialization.py", line 573, in _load
    result = unpickler.load()
  File "D:\Anaconda\lib\site-packages\torch\serialization.py", line 536, in persistent_load
    deserialized_objects[root_key] = restore_location(obj, location)
  File "D:\Anaconda\lib\site-packages\torch\serialization.py", line 119, in default_restore_location
    result = fn(storage, location)
  File "D:\Anaconda\lib\site-packages\torch\serialization.py", line 95, in _cuda_deserialize
    device = validate_cuda_device(location)
  File "D:\Anaconda\lib\site-packages\torch\serialization.py", line 79, in validate_cuda_device
    raise RuntimeError('Attempting to deserialize object on a CUDA '
RuntimeError: Attempting to deserialize object on a CUDA device but torch.cuda.is_available() is False. If you are running on a CPU-only machine, please use torch.load with map_location=torch.device('cpu') to map your storages to the CPU.
```

**After**
```bash
$ ./graftr ./model_save_2018-01-18-175659.pt
Checkpoint loaded from ./model_save_2018-01-18-175659.pt.
Type help or ? to list commands.

> ls
bi_lstm/
candidate_module_list/
final_linear_list/
operator_embedding/
position_encoding/
relation_module_list/
word_embedding/
```

##  Add new CP operator.
```bash
$ ./graftr ./model_save_2018-01-18-175659.pt
Checkpoint loaded from ./model_save_2018-01-18-175659.pt.
Type help or ? to list commands.

> ls
bi_lstm/
candidate_module_list/
final_linear_list/
operator_embedding/
position_encoding/
relation_module_list/
word_embedding/
> cp word_embedding word_embeddings
> ls
bi_lstm/
candidate_module_list/
final_linear_list/
operator_embedding/
position_encoding/
relation_module_list/
word_embedding/
word_embeddings/
> cd word_embeddings
> ls
weight
> cd ..
> cd word_embedding
> ls
weight
```

What's more, is it possible to add a function that operates on slices?     
For example, `cp word_embeddings[0] word_embeddings[107]`, 
that helps when we want to copy the embedings from one token to another in BERT.